### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,14 +15,8 @@
         "{workspaceRoot}/eslint.config.js"
       ]
     },
-    "@nx/vite:test": {
-      "cache": true,
-      "inputs": ["default", "^production"]
-    },
-    "e2e": {
-      "cache": true,
-      "inputs": ["default", "^production"]
-    }
+    "@nx/vite:test": { "cache": true, "inputs": ["default", "^production"] },
+    "e2e": { "cache": true, "inputs": ["default", "^production"] }
   },
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
@@ -35,6 +29,6 @@
     ],
     "sharedGlobals": []
   },
-  "nxCloudAccessToken": "NzhiZDgxODktNzA2MS00Yjc5LWFlNTEtN2M4Nzg4N2FmYmNjfHJlYWQtd3JpdGU=",
+  "nxCloudAccessToken": "ZWVmNjBjMTQtMmU2Yy00YmYzLWE5ODUtNGI5YTVlNzFlMjU4fHJlYWQtd3JpdGU=",
   "nxCloudUrl": "https://staging.nx.app"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://staging.nx.app/orgs/6658b0a24d7aac9cc6c3603f/workspaces/6695261da90c315c9dd95fdb

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.